### PR TITLE
fix for seeing purchaseable items without license metadata

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -204,7 +204,7 @@ RegisterNetEvent('jim-shops:ShopMenu', function(data, custom)
 				end
 			end
 			if products[i].requiresItem then
-				for _, v in pairs(products[i].requiresItem) do canSee = HasItem(v) Wait(0) end
+				for _, v in pairs(products[i].requiresItem) do canSee = HasItem(v) and hasLicense Wait(0) end
 			end
 			if canSee or (not products[i].requiresItem and not products[i].requiresLicense and not products[i].requiredGang and not products[i].requiredJob) then
 				ShopMenu[#ShopMenu+1] = {


### PR DESCRIPTION
i noticed if i didnt have a weapons license granted but had the item i was still able to see and purchase weapons. added 
```
and hasLicense
``` 
to the canSee global to check if required

tested by granting license and having the item. was able to see. revoked license, couldnt see :)